### PR TITLE
feat(propagation): Add Features settings page

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { FetchResult } from '@apollo/client';
 
 import { UpdateDatasetMutation } from '../../../../../../graphql/dataset.generated';
+import { StringMapEntry } from '../../../../../../types.generated';
+import PropagationDetails from '../../../../shared/propagation/PropagationDetails';
 import UpdateDescriptionModal from '../../../../shared/components/legacy/DescriptionModal';
 import StripMarkdownText, { removeMarkdown } from '../../../../shared/components/styled/StripMarkdownText';
 import SchemaEditableContext from '../../../../../shared/SchemaEditableContext';
@@ -26,6 +28,11 @@ const AddNewDescription = styled(Button)`
 
 const ExpandedActions = styled.div`
     height: 10px;
+`;
+
+const DescriptionWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
 `;
 
 const DescriptionContainer = styled.div`
@@ -105,6 +112,8 @@ type Props = {
     isEdited?: boolean;
     isReadOnly?: boolean;
     businessAttributeDescription?: string;
+    isPropagated?: boolean;
+    sourceDetail?: StringMapEntry[] | null;
 };
 
 const ABBREVIATED_LIMIT = 80;
@@ -120,6 +129,8 @@ export default function DescriptionField({
     original,
     isReadOnly,
     businessAttributeDescription,
+    isPropagated,
+    sourceDetail,
 }: Props) {
     const [showAddModal, setShowAddModal] = useState(false);
     const overLimit = removeMarkdown(description).length > 80;
@@ -184,25 +195,29 @@ export default function DescriptionField({
                 </>
             ) : (
                 <>
-                    <StripMarkdownText
+                    {/* <StripMarkdownText
                         limit={ABBREVIATED_LIMIT}
-                        readMore={
-                            <>
-                                <Typography.Link
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleExpanded(true);
-                                    }}
-                                >
-                                    Read More
-                                </Typography.Link>
-                            </>
-                        }
+                        // readMore={
+                        //     <>
+                        //         <Typography.Link
+                        //             onClick={(e) => {
+                        //                 e.stopPropagation();
+                        //                 handleExpanded(true);
+                        //             }}
+                        //         >
+                        //             Read More
+                        //         </Typography.Link>
+                        //     </>
+                        // }
                         suffix={EditButton}
                         shouldWrap
-                    >
+                    > */}
+                    <DescriptionWrapper>
+                        {isPropagated && <PropagationDetails sourceDetail={sourceDetail} />}
+                        &nbsp;
                         {description}
-                    </StripMarkdownText>
+                    </DescriptionWrapper>
+                    {/* </StripMarkdownText> */}
                 </>
             )}
             {isEdited && <EditedLabel>(edited)</EditedLabel>}

--- a/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
@@ -19,16 +19,29 @@ const StyledViewer = styled(Editor)`
     }
 `;
 
+const OriginalDocumentation = styled(Form.Item)`
+    margin-bottom: 0;
+`;
+
 type Props = {
     title: string;
     description?: string | undefined;
     original?: string | undefined;
+    propagatedDescription?: string | undefined;
     onClose: () => void;
     onSubmit: (description: string) => void;
     isAddDesc?: boolean;
 };
 
-export default function UpdateDescriptionModal({ title, description, original, onClose, onSubmit, isAddDesc }: Props) {
+export default function UpdateDescriptionModal({
+    title,
+    description,
+    original,
+    propagatedDescription,
+    onClose,
+    onSubmit,
+    isAddDesc,
+}: Props) {
     const [updatedDesc, setDesc] = useState(description || original || '');
 
     const handleEditorKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -72,9 +85,14 @@ export default function UpdateDescriptionModal({ title, description, original, o
                     />
                 </Form.Item>
                 {!isAddDesc && description && original && (
-                    <Form.Item label={<FormLabel>Original:</FormLabel>}>
+                    <OriginalDocumentation label={<FormLabel>Original:</FormLabel>}>
                         <StyledViewer content={original || ''} readOnly />
-                    </Form.Item>
+                    </OriginalDocumentation>
+                )}
+                {!isAddDesc && description && propagatedDescription && (
+                    <OriginalDocumentation label={<FormLabel>Propagated:</FormLabel>}>
+                        <StyledViewer content={propagatedDescription || ''} readOnly />
+                    </OriginalDocumentation>
                 )}
             </Form>
         </Modal>

--- a/datahub-web-react/src/app/entity/shared/propagation/PropagationDetails.tsx
+++ b/datahub-web-react/src/app/entity/shared/propagation/PropagationDetails.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ThunderboltOutlined } from '@ant-design/icons';
+import { Popover } from 'antd';
+import { StringMapEntry } from '../../../../types.generated';
+import PropagationEntityLink from './PropagationEntityLink';
+import { usePropagationDetails } from './utils';
+
+const PopoverWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+const PropagateThunderbolt = styled(ThunderboltOutlined)`
+    color: #8088a3;
+    font-weight: bold;
+    &:hover {
+        color: #4b39bc;
+    }
+`;
+
+const EntityWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+`;
+
+const PropagationPrefix = styled.span`
+    color: black;
+`;
+
+interface Props {
+    sourceDetail?: StringMapEntry[] | null;
+}
+
+export default function PropagationDetails({ sourceDetail }: Props) {
+    const {
+        isPropagated,
+        origin: { entity: originEntity },
+        via: { entity: viaEntity },
+    } = usePropagationDetails(sourceDetail);
+
+    if (!sourceDetail || !isPropagated) return null;
+
+    const popoverContent =
+        originEntity || viaEntity ? (
+            <PopoverWrapper>
+                Propagated description
+                <br />
+                {viaEntity && (
+                    <EntityWrapper>
+                        <PropagationPrefix>via:</PropagationPrefix>
+                        <PropagationEntityLink entity={viaEntity} />
+                    </EntityWrapper>
+                )}
+                {originEntity && originEntity.urn !== viaEntity?.urn && (
+                    <EntityWrapper>
+                        <PropagationPrefix>origin:</PropagationPrefix>
+                        <PropagationEntityLink entity={originEntity} />
+                    </EntityWrapper>
+                )}
+            </PopoverWrapper>
+        ) : undefined;
+
+    return (
+        <Popover content={popoverContent}>
+            <PropagateThunderbolt />
+        </Popover>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/propagation/PropagationEntityLink.tsx
+++ b/datahub-web-react/src/app/entity/shared/propagation/PropagationEntityLink.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { Entity, EntityType, SchemaFieldEntity } from '../../../../types.generated';
+import { GenericEntityProperties } from '../types';
+
+const PreviewImage = styled.img<{ size: number }>`
+    height: ${(props) => props.size}px;
+    width: ${(props) => props.size}px;
+    min-width: ${(props) => props.size}px;
+    object-fit: contain;
+    background-color: transparent;
+    margin: 0 3px;
+`;
+
+const StyledLink = styled(Link)`
+    display: flex;
+    align-items: center;
+`;
+
+interface Props {
+    entity: Entity;
+}
+
+export default function PropagationEntityLink({ entity }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    const isSchemaField = entity.type === EntityType.SchemaField;
+    const baseEntity = isSchemaField ? (entity as SchemaFieldEntity).parent : entity;
+
+    const logoUrl = (baseEntity as GenericEntityProperties)?.platform?.properties?.logoUrl || '';
+    let entityUrl = entityRegistry.getEntityUrl(baseEntity.type, baseEntity.urn);
+    let entityDisplayName = entityRegistry.getDisplayName(baseEntity.type, baseEntity);
+
+    if (isSchemaField) {
+        entityUrl = `${entityUrl}/${encodeURIComponent('Columns')}?schemaFilter=${encodeURIComponent(
+            (entity as SchemaFieldEntity).fieldPath,
+        )}`;
+        const schemaFieldName = entityRegistry.getDisplayName(entity.type, entity);
+        entityDisplayName = `${entityDisplayName}.${schemaFieldName}`;
+    }
+
+    return (
+        <StyledLink to={entityUrl}>
+            <PreviewImage src={logoUrl} alt="test" size={14} />
+            {entityDisplayName}
+        </StyledLink>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/propagation/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/propagation/utils.ts
@@ -1,0 +1,24 @@
+import { StringMapEntry } from '../../../../types.generated';
+import { useGetEntities } from '../useGetEntities';
+
+export function usePropagationDetails(sourceDetail?: StringMapEntry[] | null) {
+    const isPropagated = !!sourceDetail?.find((mapEntry) => mapEntry.key === 'propagated' && mapEntry.value === 'true');
+    const originEntityUrn = sourceDetail?.find((mapEntry) => mapEntry.key === 'origin')?.value || '';
+    const viaEntityUrn = sourceDetail?.find((mapEntry) => mapEntry.key === 'via')?.value || '';
+
+    const entities = useGetEntities([originEntityUrn, viaEntityUrn]);
+    const originEntity = entities.find((e) => e.urn === originEntityUrn);
+    const viaEntity = entities.find((e) => e.urn === viaEntityUrn);
+
+    return {
+        isPropagated,
+        origin: {
+            urn: originEntityUrn,
+            entity: originEntity,
+        },
+        via: {
+            urn: viaEntityUrn,
+            entity: viaEntity,
+        },
+    };
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { SectionHeader, StyledDivider } from './components';
 import UpdateDescriptionModal from '../../../../../components/legacy/DescriptionModal';
 import { EditableSchemaFieldInfo, SchemaField, SubResourceType } from '../../../../../../../../types.generated';
+import { getFieldDescriptionDetails } from '../../utils/getFieldDescriptionDetails';
+import PropagationDetails from '../../../../../propagation/PropagationDetails';
 import DescriptionSection from '../../../../../containers/profile/sidebar/AboutSection/DescriptionSection';
 import { useEntityData, useMutationUrn, useRefetch } from '../../../../../EntityContext';
 import { useSchemaRefetch } from '../../SchemaContext';
@@ -13,16 +15,18 @@ import { useUpdateDescriptionMutation } from '../../../../../../../../graphql/mu
 import analytics, { EntityActionType, EventType } from '../../../../../../../analytics';
 import SchemaEditableContext from '../../../../../../../shared/SchemaEditableContext';
 
-const DescriptionWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
 const EditIcon = styled(Button)`
     border: none;
     box-shadow: none;
     height: 20px;
     width: 20px;
+`;
+
+const DescriptionWrapper = styled.div`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: space-between;
 `;
 
 interface Props {
@@ -76,7 +80,13 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
         },
     });
 
-    const displayedDescription = editableFieldInfo?.description || expandedField.description;
+    const { schemaFieldEntity, description } = expandedField;
+    const { displayedDescription, isPropagated, sourceDetail, propagatedDescription } = getFieldDescriptionDetails({
+        schemaFieldEntity,
+        editableFieldInfo,
+        defaultDescription: description,
+    });
+
     const baDescription =
         expandedField?.schemaFieldEntity?.businessAttributes?.businessAttribute?.businessAttribute?.properties
             ?.description;
@@ -87,12 +97,17 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
             <DescriptionWrapper>
                 <div>
                     <SectionHeader>Description</SectionHeader>
-                    <DescriptionSection
-                        description={displayedDescription || ''}
-                        baDescription={baDescription || ''}
-                        baUrn={baUrn || ''}
-                        isExpandable
-                    />
+                    <DescriptionWrapper>
+                        {isPropagated && <PropagationDetails sourceDetail={sourceDetail} />}
+                        {!!displayedDescription && (
+                            <DescriptionSection
+                                description={displayedDescription || ''}
+                                baDescription={baDescription || ''}
+                                baUrn={baUrn || ''}
+                                isExpandable
+                            />
+                        )}
+                    </DescriptionWrapper>
                 </div>
                 {isSchemaEditable && (
                     <EditIcon
@@ -114,6 +129,7 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
                                 .catch(onFailMutation);
                             setIsModalVisible(false);
                         }}
+                        propagatedDescription={propagatedDescription || ''}
                         isAddDesc={!displayedDescription}
                     />
                 )}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
@@ -1,0 +1,25 @@
+import { EditableSchemaFieldInfo, SchemaFieldEntity } from '../../../../../../../types.generated';
+
+interface Props {
+    schemaFieldEntity?: SchemaFieldEntity | null;
+    editableFieldInfo?: EditableSchemaFieldInfo;
+    defaultDescription?: string | null;
+}
+
+export function getFieldDescriptionDetails({ schemaFieldEntity, editableFieldInfo, defaultDescription }: Props) {
+    const documentation = schemaFieldEntity?.documentation?.documentations?.[0];
+    const isUsingDocumentationAspect = !editableFieldInfo?.description && !!documentation;
+    const isPropagated =
+        isUsingDocumentationAspect &&
+        !!documentation?.attribution?.sourceDetail?.find(
+            (mapEntry) => mapEntry.key === 'propagated' && mapEntry.value === 'true',
+        );
+
+    const displayedDescription =
+        editableFieldInfo?.description || documentation?.documentation || defaultDescription || '';
+
+    const sourceDetail = documentation?.attribution?.sourceDetail;
+    const propagatedDescription = documentation?.documentation;
+
+    return { displayedDescription, isPropagated, sourceDetail, propagatedDescription };
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -6,6 +6,7 @@ import { useUpdateDescriptionMutation } from '../../../../../../../graphql/mutat
 import { useMutationUrn, useRefetch } from '../../../../EntityContext';
 import { useSchemaRefetch } from '../SchemaContext';
 import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
+import { getFieldDescriptionDetails } from './getFieldDescriptionDetails';
 
 export default function useDescriptionRenderer(editableSchemaMetadata: EditableSchemaMetadata | null | undefined) {
     const urn = useMutationUrn();
@@ -21,10 +22,16 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
     };
 
     return (description: string, record: SchemaField, index: number): JSX.Element => {
-        const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
-            (candidateEditableFieldInfo) => pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+        const editableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
+            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
-        const displayedDescription = relevantEditableFieldInfo?.description || description;
+        const { schemaFieldEntity } = record;
+        const { displayedDescription, isPropagated, sourceDetail } = getFieldDescriptionDetails({
+            schemaFieldEntity,
+            editableFieldInfo,
+            defaultDescription: description,
+        });
+
         const sanitizedDescription = DOMPurify.sanitize(displayedDescription);
         const original = record.description ? DOMPurify.sanitize(record.description) : undefined;
         const businessAttributeDescription =
@@ -43,7 +50,7 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                 baExpanded={!!expandedBARows[index]}
                 description={sanitizedDescription}
                 original={original}
-                isEdited={!!relevantEditableFieldInfo?.description}
+                isEdited={!!editableFieldInfo?.description}
                 onUpdate={(updatedDescription) =>
                     updateDescription({
                         variables: {
@@ -56,6 +63,8 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                         },
                     }).then(refresh)
                 }
+                isPropagated={isPropagated}
+                sourceDetail={sourceDetail}
                 isReadOnly
             />
         );

--- a/datahub-web-react/src/app/entity/shared/useGetEntities.ts
+++ b/datahub-web-react/src/app/entity/shared/useGetEntities.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { useGetEntitiesQuery } from '../../../graphql/entity.generated';
+import { Entity } from '../../../types.generated';
+
+export function useGetEntities(urns: string[]): Entity[] {
+    const [verifiedUrns, setVerifiedUrns] = useState<string[]>([]);
+
+    useEffect(() => {
+        urns.forEach((urn) => {
+            if (urn.startsWith('urn:li:') && !verifiedUrns.includes(urn)) {
+                setVerifiedUrns((prevUrns) => [...prevUrns, urn]);
+            }
+        });
+    }, [urns, verifiedUrns]);
+
+    const { data } = useGetEntitiesQuery({ variables: { urns: verifiedUrns }, skip: !verifiedUrns.length });
+    return (data?.entities || []) as Entity[];
+}

--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import {
     FilterOutlined,
     TeamOutlined,
     PushpinOutlined,
+    ControlOutlined,
 } from '@ant-design/icons';
 import { Redirect, Route, useHistory, useLocation, useRouteMatch, Switch } from 'react-router';
 import styled from 'styled-components';
@@ -17,10 +18,16 @@ import { ManagePermissions } from '../permissions/ManagePermissions';
 import { useAppConfig } from '../useAppConfig';
 import { AccessTokens } from './AccessTokens';
 import { Preferences } from './Preferences';
+import { Features } from './features/Features';
 import { ManageViews } from '../entity/view/ManageViews';
 import { useUserContext } from '../context/useUserContext';
 import { ManageOwnership } from '../entity/ownership/ManageOwnership';
 import ManagePosts from './posts/ManagePosts';
+
+const MenuItem = styled(Menu.Item)`
+    display: flex;
+    align-items: center;
+`;
 
 const PageContainer = styled.div`
     display: flex;
@@ -59,6 +66,17 @@ const ItemTitle = styled.span`
 
 const menuStyle = { width: 256, 'margin-top': 8, overflow: 'hidden auto' };
 
+const NewTag = styled.span`
+    padding: 4px 8px;
+    margin-left: 8px;
+
+    border-radius: 24px;
+    background: #f1fbfe;
+
+    color: #09739a;
+    font-size: 12px;
+`;
+
 /**
  * URL Paths for each settings page.
  */
@@ -70,6 +88,7 @@ const PATHS = [
     { path: 'views', content: <ManageViews /> },
     { path: 'ownership', content: <ManageOwnership /> },
     { path: 'posts', content: <ManagePosts /> },
+    { path: 'features', content: <Features /> },
 ];
 
 /**
@@ -80,6 +99,7 @@ const DEFAULT_PATH = PATHS[0];
 export const SettingsPage = () => {
     const { path, url } = useRouteMatch();
     const { pathname } = useLocation();
+
     const history = useHistory();
     const subRoutes = PATHS.map((p) => p.path.replace('/', ''));
     const currPathName = pathname.replace(path, '');
@@ -101,6 +121,7 @@ export const SettingsPage = () => {
     const showViews = isViewsEnabled || false;
     const showOwnershipTypes = me && me?.platformPrivileges?.manageOwnershipTypes;
     const showHomePagePosts = me && me?.platformPrivileges?.manageGlobalAnnouncements && !readOnlyModeEnabled;
+    const showFeatures = true; // TODO: Add feature flag for this
 
     return (
         <PageContainer>
@@ -143,6 +164,13 @@ export const SettingsPage = () => {
                     )}
                     {(showViews || showOwnershipTypes || showHomePagePosts) && (
                         <Menu.ItemGroup title="Manage">
+                            {showFeatures && (
+                                <MenuItem key="features">
+                                    <ControlOutlined />
+                                    <ItemTitle>Features</ItemTitle>
+                                    <NewTag>New!</NewTag>
+                                </MenuItem>
+                            )}
                             {showViews && (
                                 <Menu.Item key="views">
                                     <FilterOutlined /> <ItemTitle>My Views</ItemTitle>

--- a/datahub-web-react/src/app/settings/features/Feature.tsx
+++ b/datahub-web-react/src/app/settings/features/Feature.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Divider, Typography, Switch, Card } from 'antd';
+import { ArrowRightOutlined } from '@ant-design/icons';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+
+const Title = styled(Typography.Title)`
+    && {
+        margin-bottom: 8px;
+    }
+`;
+
+const FeatureRow = styled.div`
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 8px;
+`;
+
+const FeatureOptionRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+
+    &:not(:last-child) {
+        margin-bottom: 8px;
+    }
+`;
+
+const DescriptionText = styled(Typography.Text)`
+    color: ${ANTD_GRAY[7]};
+    font-size: 11px;
+`;
+
+const SettingTitle = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    margin-bottom: 4px;
+`;
+
+const OptionTitle = styled(Typography.Text)`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+`;
+
+const learnMoreLinkStyle = {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    color: '#1890FF',
+    fontSize: '12px',
+    cursor: 'pointer',
+};
+
+const NewTag = styled.div`
+    padding: 4px 8px;
+
+    border-radius: 24px;
+    background: #f1fbfe;
+
+    color: #09739a;
+    font-size: 12px;
+`;
+
+const DatahubOnlyTag = styled.div`
+    padding: 2px 8px;
+
+    border-radius: 24px;
+    background: #c9fff2;
+
+    color: #50a494;
+    font-size: 12px;
+`;
+
+export interface FeatureType {
+    key: string;
+    title: string;
+    description: string;
+    options: Array<{
+        key: string;
+        title: string;
+        description: string;
+        isAvailable: boolean;
+        checked: boolean;
+        onChange?: (checked: boolean) => void;
+    }>;
+    isNew: boolean;
+    learnMoreLink?: string;
+}
+
+export const Feature = ({ key, title, description, options, isNew, learnMoreLink }: FeatureType) => (
+    <Card style={{ marginBottom: '1rem' }} key={key}>
+        <FeatureRow>
+            <div style={{ flex: 1 }}>
+                <SettingTitle>
+                    <Title level={5} style={{ marginBottom: 0 }}>
+                        {title}
+                    </Title>
+                    {isNew && <NewTag>New!</NewTag>}
+                </SettingTitle>
+                <div>
+                    <Typography.Paragraph type="secondary">{description}</Typography.Paragraph>
+                </div>
+            </div>
+            <div>
+                {learnMoreLink && (
+                    <a href={learnMoreLink} target="_blank" style={learnMoreLinkStyle} rel="noreferrer">
+                        Learn more <ArrowRightOutlined />
+                    </a>
+                )}
+            </div>
+        </FeatureRow>
+        <Card style={{ margin: `16px auto` }}>
+            {options.map((option, index) => (
+                <>
+                    <FeatureOptionRow key={option.key}>
+                        <span>
+                            <OptionTitle>
+                                <span>{option.title}</span>
+                                {!option.isAvailable && (
+                                    <DatahubOnlyTag>Only available on DataHub Cloud</DatahubOnlyTag>
+                                )}
+                            </OptionTitle>
+                            <div>
+                                <DescriptionText>{option.description}</DescriptionText>
+                            </div>
+                        </span>
+                        <Switch
+                            checked={option.checked}
+                            onChange={(checked) => (option.onChange ? option.onChange(checked) : null)}
+                            disabled={!option.isAvailable}
+                        />
+                    </FeatureOptionRow>
+                    {index !== options.length - 1 && <Divider />}
+                </>
+            ))}
+        </Card>
+    </Card>
+);

--- a/datahub-web-react/src/app/settings/features/Features.tsx
+++ b/datahub-web-react/src/app/settings/features/Features.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Divider, Typography } from 'antd';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Feature, FeatureType } from './Feature';
+
+import { useGetDocPropagationSettings, useUpdateDocPropagationSettings } from './useDocPropagationSettings';
+
+const Page = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+`;
+
+const SourceContainer = styled.div`
+    width: 80%;
+    padding-top: 20px;
+    padding-right: 40px;
+    padding-left: 40px;
+`;
+const Container = styled.div`
+    padding-top: 0px;
+`;
+
+const Title = styled(Typography.Title)`
+    && {
+        margin-bottom: 8px;
+    }
+`;
+
+export const Features = () => {
+    /*
+     * Note: When adding new features, make sure to update the features array below
+     * and create a hook file for the new feature in the same directory
+     */
+
+    // Hooks to get and update the document propagation settings
+    const { isColPropagateChecked, setIsColPropagateChecked } = useGetDocPropagationSettings();
+    const { updateDocPropagation } = useUpdateDocPropagationSettings();
+
+    // Features to display
+    const features: FeatureType[] = [
+        {
+            key: uuidv4(),
+            title: 'Documentation Propagation',
+            description: 'Automatically propagate documentation from upstream to downstream columns and assets.',
+            options: [
+                {
+                    key: uuidv4(),
+                    title: 'Column Level Propagation',
+                    description:
+                        'Propagate new documentation from upstream to downstream columns based on column-level lineage relationships.',
+                    isAvailable: true,
+                    checked: isColPropagateChecked,
+                    onChange: (checked: boolean) => {
+                        setIsColPropagateChecked(checked);
+                        updateDocPropagation(checked);
+                    },
+                },
+                {
+                    key: uuidv4(),
+                    title: 'Asset Level Propagation',
+                    description:
+                        'Propagate new documentation from upstream to downstream assets based on data lineage relationships.',
+                    isAvailable: false,
+                    checked: false,
+                },
+                {
+                    key: uuidv4(),
+                    title: 'Rollback Propagation Changes',
+                    description: 'Rollback documentation changes.',
+                    isAvailable: false,
+                    checked: false,
+                },
+                {
+                    key: uuidv4(),
+                    title: 'Initialize Propagation',
+                    description: 'Backfill existing documentation from upstream to downstream columns/assets.',
+                    isAvailable: false,
+                    checked: false,
+                },
+            ],
+            isNew: true,
+            learnMoreLink: '#', // TODO: Add URL to Docs page
+        },
+    ];
+
+    // Render
+    return (
+        <Page>
+            <SourceContainer>
+                <Container>
+                    <div>
+                        <Title level={2}>Features</Title>
+                        <Typography.Paragraph type="secondary">
+                            Explore and configure specific features
+                        </Typography.Paragraph>
+                    </div>
+                </Container>
+                <Divider />
+                {features.map((feature) => (
+                    <Feature {...feature} />
+                ))}
+            </SourceContainer>
+        </Page>
+    );
+};

--- a/datahub-web-react/src/app/settings/features/useDocPropagationSettings.ts
+++ b/datahub-web-react/src/app/settings/features/useDocPropagationSettings.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { message } from 'antd';
+
+import {
+    useGetDocPropagationSettingsQuery,
+    useUpdateDocPropagationSettingsMutation,
+} from '../../../graphql/app.generated';
+
+// Hook to get the document propagation settings & manage state
+export const useGetDocPropagationSettings = () => {
+    const { data, refetch } = useGetDocPropagationSettingsQuery();
+    const [isColPropagateChecked, setIsColPropagateChecked] = useState<boolean>(false);
+
+    useEffect(() => {
+        const docPropSetting = data?.docPropagationSettings?.docColumnPropagation;
+        if (docPropSetting !== undefined) setIsColPropagateChecked(!!docPropSetting);
+    }, [data]);
+
+    return {
+        isColPropagateChecked,
+        setIsColPropagateChecked,
+        refetch,
+    };
+};
+
+// Hook to update the document propagation settings
+export const useUpdateDocPropagationSettings = () => {
+    const [updateDocPropagationSettings] = useUpdateDocPropagationSettingsMutation();
+    const { refetch } = useGetDocPropagationSettingsQuery();
+
+    const updateDocPropagation = async (checked: boolean) => {
+        try {
+            await updateDocPropagationSettings({
+                variables: {
+                    input: {
+                        docColumnPropagation: checked,
+                    },
+                },
+            });
+            refetch();
+            message.success('Successfully updated documentation propagation settings');
+        } catch (e) {
+            message.error('Failed to update documentation propagation settings');
+            refetch();
+        }
+    };
+
+    return { updateDocPropagation };
+};

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -89,6 +89,16 @@ query getGlobalViewsSettings {
     }
 }
 
+query getDocPropagationSettings {
+    docPropagationSettings {
+        docColumnPropagation
+    }
+}
+
 mutation updateGlobalViewsSettings($input: UpdateGlobalViewsSettingsInput!) {
     updateGlobalViewsSettings(input: $input)
+}
+
+mutation updateDocPropagationSettings($input: UpdateDocPropagationSettingsInput!) {
+    updateDocPropagationSettings(input: $input)
 }


### PR DESCRIPTION
Adds a new page to `Settings` that presents options for toggling app features on/off.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
